### PR TITLE
Sanitize Environment from Target State

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can learn more about balena Labels in the [Documentation](https://www.balena
 - Provides Services Panel to start, stop, restart Containers.
 - Allows to filter Logs using Regex pattern.
 - Requires Confirmation to restart all Services and reboot the device.
+- Environment Variables sanitized from Target State.
 
 ## Balena Supervisor
 

--- a/src/volkovlabs-balenasupervisor-datasource/api/v2.ts
+++ b/src/volkovlabs-balenasupervisor-datasource/api/v2.ts
@@ -3,6 +3,7 @@ import { FieldType, MutableDataFrame } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { DefaultQuery, RequestTypeValue } from '../constants';
 import { Query, StateStatus, TargetState } from '../types';
+import { sanitizeKeys } from '../utils';
 import { Api } from './api';
 
 /**
@@ -194,7 +195,10 @@ export async function getTargetState(this: Api): Promise<TargetState | null> {
     return null;
   }
 
-  return targetState;
+  /**
+   * Sanitize Environment Variables
+   */
+  return sanitizeKeys(targetState, ['environment']);
 }
 
 /**

--- a/src/volkovlabs-balenasupervisor-datasource/utils.ts
+++ b/src/volkovlabs-balenasupervisor-datasource/utils.ts
@@ -47,3 +47,15 @@ export const getSupervisorDatasource = async (data: PanelData): Promise<DataSour
 
   return datasource;
 };
+
+/**
+ * Sanitize keys
+ */
+export const sanitizeKeys = (obj: any, keys: string[]): any =>
+  obj !== Object(obj)
+    ? obj
+    : Array.isArray(obj)
+    ? obj.map((item) => sanitizeKeys(item, keys))
+    : Object.keys(obj)
+        .filter((k) => !keys.includes(k))
+        .reduce((acc, x) => Object.assign(acc, { [x]: sanitizeKeys(obj[x], keys) }), {});


### PR DESCRIPTION
Resolves #38.

To avoid exposing Environment Variables from all containers, it's sanitized.
If you need to use Environment Variables in Grafana, consider using Environment Data Source: https://github.com/volkovlabs/volkovlabs-env-datasource